### PR TITLE
Fixed touch action on mobile.

### DIFF
--- a/lib/SwipeableWrapper/index.jsx
+++ b/lib/SwipeableWrapper/index.jsx
@@ -176,7 +176,6 @@ const SwipeableWrapper = forwardRef(
           style={{
             width: `${children.length * 100}%`,
             display: "flex",
-            touchAction: "none",
             transition: "transform",
             transitionTimingFunction,
             willChange: "transform",


### PR DESCRIPTION
Problem: Currently, touch action is disabled on mobile due to which scrolling is not working.

Solution: Removed `touch-action: none` property.

